### PR TITLE
列表模版，时间列裁切行为优化

### DIFF
--- a/Mac/Echo/Template/List/ECOTemplateListDetailCell.h
+++ b/Mac/Echo/Template/List/ECOTemplateListDetailCell.h
@@ -15,6 +15,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy) NSString *title;
 @property (nonatomic, assign) BOOL selectedMark;
 
+/// 控制 title 文字的裁切
+@property (nonatomic) NSLineBreakMode titleLineBreak;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Mac/Echo/Template/List/ECOTemplateListDetailCell.m
+++ b/Mac/Echo/Template/List/ECOTemplateListDetailCell.m
@@ -48,6 +48,14 @@
     _selectedMark = selectedMark;
     self.bgBox.hidden = !_selectedMark;
 }
+
+- (NSLineBreakMode)titleLineBreak {
+    return self.titleLabel.cell.lineBreakMode;
+}
+- (void)setTitleLineBreak:(NSLineBreakMode)titleLineBreak {
+    self.titleLabel.cell.lineBreakMode = titleLineBreak;
+}
+
 #pragma mark - getters
 - (NSBox *)bgBox {
     if (!_bgBox) {

--- a/Mac/Echo/Template/List/ECOTemplateListDetailViewController.m
+++ b/Mac/Echo/Template/List/ECOTemplateListDetailViewController.m
@@ -192,6 +192,9 @@ NSTableViewDataSource>
     NSDictionary *item = self.bizArray[row];
     NSDictionary *listItem = item[@"list"];
     NSString *textString = listItem[identifier] ?: @"";
+    // time 有大写有小写的，没法用 isEqual
+    BOOL isTimeColumn = ([identifier caseInsensitiveCompare:@"time"] == NSOrderedSame);
+    cell.titleLineBreak = isTimeColumn ? NSLineBreakByTruncatingHead : NSLineBreakByClipping;
     cell.title = textString;
     cell.selectedMark = self.selectedIndex == row;
     return cell;


### PR DESCRIPTION
现在的时间这列，有时候显示不下就只显示日期。看日志的时候，通常时分秒更重要，就只能手动把时间列拉大点。

这个 PR 把时间列的裁切方式进行了调整，优先显示后面的信息，显示不下基本不用去调整列宽了。